### PR TITLE
Fix package.json main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/darlal/obsidian-switcher-plus"
   },
-  "main": "./src/switcher-plus-volcano.js",
+  "main": "./dist/volcano/switcher-plus-volcano.js",
   "scripts": {
     "build": "npm run lint && rollup -c rollup.config.js",
     "lint": "eslint .",


### PR DESCRIPTION
This allows you to just `git clone` the plugin directly into the `volcano/plugins` directory.