### PR TITLE
Add basic emacs-style keybindings for cycling through items

### DIFF
--- a/src/modules/switcherPlus.js
+++ b/src/modules/switcherPlus.js
@@ -25,6 +25,21 @@ export default (app) => {
 
       this.mode = Mode.Standard;
       this.symbolTargetPath = null;
+
+      this.scope.registerKey(['Ctrl'], 'n', this.nextItem.bind(this.chooser));
+      this.scope.registerKey(['Ctrl'], 'p', this.previousItem.bind(this.chooser));
+    }
+
+    previousItem() {
+      if (this.chooser.isOpen) {
+        this.setSelectedItem(this.selectedItem - 1);
+      }
+    }
+
+    nextItem() {
+      if (this.chooser.isOpen) {
+        this.setSelectedItem(this.selectedItem + 1);
+      }
     }
 
     openInMode(mode) {

--- a/src/modules/switcherPlus.js
+++ b/src/modules/switcherPlus.js
@@ -32,13 +32,13 @@ export default (app) => {
 
     previousItem() {
       if (this.chooser.isOpen) {
-        this.setSelectedItem(this.selectedItem - 1);
+        this.setSelectedItem(this.selectedItem - 1, true);
       }
     }
 
     nextItem() {
       if (this.chooser.isOpen) {
-        this.setSelectedItem(this.selectedItem + 1);
+        this.setSelectedItem(this.selectedItem + 1, true);
       }
     }
 


### PR DESCRIPTION
This PR adds basic keybindings for cycling through the switcher items (ctrl-n/ctrl-p).

- [x] ctrl-n/ctrl-p to go up and down the list

I have only tested this on macOS. I am not sure how Obsidian handles OS-specific keybindings so this might need some tweaks.