### PR TITLE
Allow standard mode to include open files at the top

### DIFF
--- a/src/settings/__tests__/switcherPlusSettings.test.ts
+++ b/src/settings/__tests__/switcherPlusSettings.test.ts
@@ -1,19 +1,17 @@
-import { LinkType, SettingsData, SymbolType } from 'src/types';
-import SwitcherPlusPlugin from 'src/main';
-import { SwitcherPlusSettings } from 'src/settings';
 import { Chance } from 'chance';
+import { mock, MockProxy } from 'jest-mock-extended';
 import {
-  App,
-  QuickSwitcherOptions,
-  InstalledPlugin,
-  QuickSwitcherPluginInstance,
+  App, QuickSwitcherOptions, InstalledPlugin, QuickSwitcherPluginInstance,
   InternalPlugins,
 } from 'obsidian';
-import { mock, MockProxy } from 'jest-mock-extended';
+import SwitcherPlusPlugin from 'src/main';
+import { SwitcherPlusSettings } from 'src/settings';
+import { LinkType, SettingsData, SymbolType } from 'src/types';
 
 const chance = new Chance();
 
 function transientSettingsData(useDefault: boolean): SettingsData {
+  const standardIncludeOpenFiles = useDefault ? true : chance.bool();
   const alwaysNewPaneForSymbols = useDefault ? false : chance.bool();
   const useActivePaneForSymbolsOnMobile = useDefault ? false : chance.bool();
   const symbolsInLineOrder = useDefault ? true : chance.bool();
@@ -48,6 +46,7 @@ function transientSettingsData(useDefault: boolean): SettingsData {
   const excludeLinkSubTypes = useDefault ? 0 : LinkType.Block;
 
   const data: SettingsData = {
+    standardIncludeOpenFiles,
     alwaysNewPaneForSymbols,
     useActivePaneForSymbolsOnMobile,
     symbolsInLineOrder,

--- a/src/settings/switcherPlusSettingTab.ts
+++ b/src/settings/switcherPlusSettingTab.ts
@@ -1,6 +1,7 @@
 import { App, Modal, PluginSettingTab, Setting } from 'obsidian';
-import { LinkType, SymbolType } from 'src/types';
 import { SwitcherPlusSettings } from 'src/settings';
+import { LinkType, SymbolType } from 'src/types';
+
 import type SwitcherPlusPlugin from '../main';
 
 export class SwitcherPlusSettingTab extends PluginSettingTab {
@@ -16,10 +17,20 @@ export class SwitcherPlusSettingTab extends PluginSettingTab {
     const { containerEl, settings } = this;
 
     containerEl.empty();
+    this.setStandardModeSettingsGroup(containerEl, settings);
     this.setSymbolModeSettingsGroup(containerEl, settings);
     this.setEditorModeSettingsGroup(containerEl, settings);
     SwitcherPlusSettingTab.setWorkspaceModeSettingsGroup(containerEl, settings);
     this.setHeadingsModeSettingsGroup(containerEl, settings);
+  }
+
+  private setStandardModeSettingsGroup(
+    containerEl: HTMLElement,
+    settings: SwitcherPlusSettings,
+  ): void {
+    containerEl.createEl('h2', { text: 'Standard Mode Settings' });
+
+    SwitcherPlusSettingTab.addStandardIncludeOpenFilesToggle(containerEl, settings);
   }
 
   private setEditorModeSettingsGroup(
@@ -234,6 +245,23 @@ export class SwitcherPlusSettingTab extends PluginSettingTab {
           SwitcherPlusSettingTab.saveChanges(settings);
         });
       });
+  }
+
+  private static addStandardIncludeOpenFilesToggle(
+    containerEl: HTMLElement,
+    settings: SwitcherPlusSettings,
+  ): void {
+    new Setting(containerEl)
+      .setName('Include open files')
+      .setDesc('Include open files at the top of standard suggestions, when selected, make the open file active instead of opening another pane.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(settings.standardIncludeOpenFiles)
+          .onChange((value) => {
+            settings.standardIncludeOpenFiles = value
+            SwitcherPlusSettingTab.saveChanges(settings);
+          }),
+      );
   }
 
   private static setEditorListCommand(

--- a/src/settings/switcherPlusSettings.ts
+++ b/src/settings/switcherPlusSettings.ts
@@ -1,7 +1,7 @@
+import { QuickSwitcherOptions } from 'obsidian';
+import type SwitcherPlusPlugin from 'src/main';
 import { SettingsData, SymbolType } from 'src/types';
 import { getSystemSwitcherInstance } from 'src/utils';
-import type SwitcherPlusPlugin from 'src/main';
-import { QuickSwitcherOptions } from 'obsidian';
 
 export class SwitcherPlusSettings {
   private data: SettingsData;
@@ -14,6 +14,7 @@ export class SwitcherPlusSettings {
     enabledSymbolTypes[SymbolType.Heading] = true;
 
     return {
+      standardIncludeOpenFiles: true,
       alwaysNewPaneForSymbols: false,
       useActivePaneForSymbolsOnMobile: false,
       symbolsInLineOrder: true,
@@ -56,6 +57,14 @@ export class SwitcherPlusSettings {
   get showExistingOnly(): boolean {
     // forward to core switcher settings
     return this.builtInSystemOptions?.showExistingOnly;
+  }
+
+  get standardIncludeOpenFiles(): boolean {
+    return this.data.standardIncludeOpenFiles;
+  }
+
+  set standardIncludeOpenFiles(value: boolean) {
+    this.data.standardIncludeOpenFiles = value;
   }
 
   get alwaysNewPaneForSymbols(): boolean {

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -4,6 +4,7 @@ import { SystemSwitcher, SwitcherPlus, AnySuggestion, Mode } from 'src/types';
 import { getSystemSwitcherInstance, isFileSuggestion } from 'src/utils';
 
 import { EditorHandler } from '../Handlers/editorHandler';
+import { SwitcherPlusSettings } from '../settings';
 import { Keymap } from './keymap';
 import { ModeHandler } from './modeHandler';
 
@@ -25,6 +26,7 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
   const SwitcherPlusModal = class extends SystemSwitcherModal implements SwitcherPlus {
     private exMode: ModeHandler;
     editorHandler: EditorHandler;
+    settings: SwitcherPlusSettings;
 
     constructor(app: App, public plugin: SwitcherPlusPlugin) {
       super(app, plugin.options.builtInSystemOptions);
@@ -34,6 +36,7 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
       const exKeymap = new Keymap(this.scope, this.chooser, this.containerEl);
       this.exMode = new ModeHandler(app, plugin.options, exKeymap);
       this.editorHandler = new EditorHandler(app, plugin.options);
+      this.settings = plugin.options
     }
 
     openInMode(mode: Mode): void {
@@ -61,7 +64,11 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
       }
     }
 
+    // called by updateSuggestions
     getSuggestions(query: string): AnySuggestion[] {
+      if (!this.settings.standardIncludeOpenFiles) {
+        return super.getSuggestions(query);
+      }
       // console.log('overwrite getSuggestions', query);
       const suggs: AnySuggestion[] = [];
       const editorFiles: Filepaths = {};

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -30,7 +30,6 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
 
     constructor(app: App, public plugin: SwitcherPlusPlugin) {
       super(app, plugin.options.builtInSystemOptions);
-      console.log('construct quickswitcher++');
 
       plugin.options.shouldShowAlias = this.shouldShowAlias;
       const exKeymap = new Keymap(this.scope, this.chooser, this.containerEl);

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -1,9 +1,11 @@
-import { Keymap } from './keymap';
-import { getSystemSwitcherInstance } from 'src/utils';
-import { ModeHandler } from './modeHandler';
-import SwitcherPlusPlugin from 'src/main';
 import { App, QuickSwitcherOptions } from 'obsidian';
+import SwitcherPlusPlugin from 'src/main';
 import { SystemSwitcher, SwitcherPlus, AnySuggestion, Mode } from 'src/types';
+import { getSystemSwitcherInstance, isFileSuggestion } from 'src/utils';
+
+import { EditorHandler } from '../Handlers/editorHandler';
+import { Keymap } from './keymap';
+import { ModeHandler } from './modeHandler';
 
 interface SystemSwitcherConstructor extends SystemSwitcher {
   new (app: App, builtInOptions: QuickSwitcherOptions): SystemSwitcher;
@@ -22,13 +24,16 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
 
   const SwitcherPlusModal = class extends SystemSwitcherModal implements SwitcherPlus {
     private exMode: ModeHandler;
+    editorHandler: EditorHandler;
 
     constructor(app: App, public plugin: SwitcherPlusPlugin) {
       super(app, plugin.options.builtInSystemOptions);
+      console.log('construct quickswitcher++');
 
       plugin.options.shouldShowAlias = this.shouldShowAlias;
       const exKeymap = new Keymap(this.scope, this.chooser, this.containerEl);
       this.exMode = new ModeHandler(app, plugin.options, exKeymap);
+      this.editorHandler = new EditorHandler(app, plugin.options);
     }
 
     openInMode(mode: Mode): void {
@@ -51,12 +56,37 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
       exMode.insertSessionOpenModeCommandString(inputEl);
 
       if (!exMode.updateSuggestions(inputEl.value, chooser)) {
+        // console.log('system switcher updateSuggestions');
         super.updateSuggestions();
       }
     }
 
+    getSuggestions(query: string): AnySuggestion[] {
+      // console.log('overwrite getSuggestions', query);
+      const suggs: AnySuggestion[] = [];
+      const editorFiles: Filepaths = {};
+
+      // insert editor handler suggestions at the top
+      EditorHandler.getOpenFileSuggestions(this.app, query).forEach(sugg => {
+        editorFiles[sugg.item.view.file?.path] = true
+        suggs.push(sugg)
+      })
+
+      // system switcher suggestions
+      super.getSuggestions(query).forEach(sugg => {
+        if (isFileSuggestion(sugg)) {
+          // ignore file suggestion whose path is already in the editor suggestions
+          if (editorFiles[sugg.file.path]) return
+        }
+        suggs.push(sugg)
+      })
+      // console.log('getSuggestions', suggs)
+      return suggs
+    }
+
     onChooseSuggestion(item: AnySuggestion, evt: MouseEvent | KeyboardEvent) {
       if (!this.exMode.onChooseSuggestion(item, evt)) {
+        // console.log('system switcher onChooseSuggestion', item);
         super.onChooseSuggestion(item, evt);
       }
     }
@@ -69,4 +99,9 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
   };
 
   return new SwitcherPlusModal(app, plugin);
+}
+
+
+interface Filepaths {
+  [key: string]: boolean
 }

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -1,17 +1,8 @@
-import {
-  App,
-  Chooser,
-  EditorPosition,
-  EmbedCache,
-  FuzzyMatch,
-  HeadingCache,
-  LinkCache,
-  PreparedQuery,
-  TagCache,
-  TFile,
-  WorkspaceLeaf,
-} from 'obsidian';
 import type { SuggestModal } from 'obsidian';
+import {
+  App, Chooser, EditorPosition, EmbedCache, FuzzyMatch, HeadingCache,
+  LinkCache, PreparedQuery, TagCache, TFile, WorkspaceLeaf,
+} from 'obsidian';
 import type { InputInfo } from 'src/switcherPlus/inputInfo';
 
 export enum Mode {
@@ -139,6 +130,7 @@ export interface TargetInfo {
 }
 
 export interface SettingsData {
+  standardIncludeOpenFiles: boolean;
   alwaysNewPaneForSymbols: boolean;
   useActivePaneForSymbolsOnMobile: boolean;
   symbolsInLineOrder: boolean;

--- a/styles.css
+++ b/styles.css
@@ -43,3 +43,19 @@
     border: 0px;
     padding-left: 36px;
 }
+
+/* editor suggestion style */
+.qsp-editor-suggestion {
+    box-shadow: 3px 0px 0 #ec9f2b inset;
+    background: #ec9f2b33;
+}
+.qsp-editor-suggestion:after {
+    content: "open editor";
+    float: right;
+    font-size: 10px;
+    font-weight: bold;
+}
+.suggestion-item.is-selected.qsp-editor-suggestion {
+    border-radius: 0;
+    background: #ec9f2b5d;
+}


### PR DESCRIPTION
[Quick Switcher++](https://github.com/darlal/obsidian-switcher-plus) is a very helpful tool, it allows me to search for open editors by typing a special prefix (`edt` by default) in the quick switcher. But I think it’s still not very intuitive, I want the “search any file and open it” action and “search for existing open file and activate it” to be combined into one thing to use.

In this PR I add a new setting item called “Include open files”. When it’s enabled, the switcher modal shows all the open files at the top with a different color style. If the open file is chosen, make that pane active; Other suggestions behave the same as the original, opening the file in the active pane.

https://i.imgur.com/bGLcQKl.mp4

The CSS color styles could be removed, it's included just for a demonstration purpose.