### PR TITLE
Implement "Command List" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Find what you're looking for faster, using Quick Switcher++. An [Obsidian.md](ht
   * [Configuration](#workspace-configuration)
 * [Navigate between your Starred notes](#navigate-starred-notes)
   * [Configuration](#starred-configuration)
+* [Run commands](#run-commands)
+  * [Configuration](#command-configuration)
 * [Global Commands for Hotkeys/Shortcuts](#global-commands-for-hotkeys)
 
 ## Demo
@@ -114,7 +116,17 @@ Note: the built-in system [Starred Notes](https://help.obsidian.md/Plugins/Starr
 
 | Setting                  | Description | Default |
 |--------------------------|-------------|---------|
-| Starred list mode trigger | Character that will trigger workspace list mode in the switcher. | `'` |
+| Starred list mode trigger | Character that will trigger starred list mode in the switcher. | `'` |
+
+## Run Commands
+
+View, search, and run Obsidian commands quickly using the default `>` command.
+
+### Command configuration
+
+| Setting                  | Description | Default |
+|--------------------------|-------------|---------|
+| Command list mode trigger | Character that will trigger command list mode in the switcher. | `>` |
 
 ## Global Commands for Hotkeys
 
@@ -126,6 +138,7 @@ The following Global Commands are registered by the plugin, which can be used fo
 * `Quick Switcher++: Open in Workspaces Mode`
 * `Quick Switcher++: Open in Headings Mode`
 * `Quick Switcher++: Open in Starred Mode`
+* `Quick Switcher++: Open in Commands Mode`
 
 ## Installation
 

--- a/src/Handlers/__tests__/commandHandler.test.ts
+++ b/src/Handlers/__tests__/commandHandler.test.ts
@@ -1,0 +1,270 @@
+import { Mode, CommandSuggestion } from 'src/types';
+import { InputInfo } from 'src/switcherPlus';
+import { CommandHandler, COMMAND_PALETTE_PLUGIN_ID } from 'src/Handlers';
+import { SwitcherPlusSettings } from 'src/settings/switcherPlusSettings';
+import {
+  App,
+  fuzzySearch,
+  InstalledPlugin,
+  InternalPlugins,
+  prepareQuery,
+  renderResults,
+  CommandPalettePluginInstance,
+  Command,
+} from 'obsidian';
+import {
+  makePreparedQuery,
+  makeFuzzyMatch,
+  commandTrigger,
+  makeCommandItem,
+} from '@fixtures';
+import { mock, MockProxy } from 'jest-mock-extended';
+
+const expectedCommandName = 'Command 1';
+
+function makeCommandPalettePluginInstall(): MockProxy<InstalledPlugin> {
+  const mockInstance = mock<CommandPalettePluginInstance>({
+    id: COMMAND_PALETTE_PLUGIN_ID,
+    options: {
+      pinned: null,
+    },
+  });
+
+  return mock<InstalledPlugin>({
+    enabled: true,
+    instance: mockInstance,
+  });
+}
+
+function makeInternalPluginList(
+  commandPalettePlugin: MockProxy<InstalledPlugin>,
+): MockProxy<InternalPlugins> {
+  const mockPlugins = mock<Record<string, InstalledPlugin>>({
+    [COMMAND_PALETTE_PLUGIN_ID]: commandPalettePlugin,
+  });
+
+  const mockInternalPlugins = mock<InternalPlugins>({ plugins: mockPlugins });
+
+  mockInternalPlugins.getPluginById.mockImplementation((id) => mockPlugins[id]);
+
+  return mockInternalPlugins;
+}
+
+describe('commandHandler', () => {
+  let settings: SwitcherPlusSettings;
+  let mockApp: MockProxy<App>;
+  let mockInternalPlugins: MockProxy<InternalPlugins>;
+  let mockCommandPalettePluginInstance: MockProxy<CommandPalettePluginInstance>;
+  let mockCommands: Command[];
+  let sut: CommandHandler;
+
+  beforeAll(() => {
+    const commandPalettePluginInstall = makeCommandPalettePluginInstall();
+    mockCommandPalettePluginInstance =
+      commandPalettePluginInstall.instance as MockProxy<CommandPalettePluginInstance>;
+
+    mockCommands = [
+      makeCommandItem(),
+      makeCommandItem(),
+      makeCommandItem(),
+      makeCommandItem(),
+      makeCommandItem({ name: expectedCommandName }),
+    ];
+
+    mockInternalPlugins = makeInternalPluginList(commandPalettePluginInstall);
+    mockApp = mock<App>({
+      internalPlugins: mockInternalPlugins,
+      commands: {
+        listCommands: jest.fn(() => mockCommands),
+        executeCommandById: jest.fn(),
+      },
+    });
+
+    settings = new SwitcherPlusSettings(null);
+    jest.spyOn(settings, 'commandListCommand', 'get').mockReturnValue(commandTrigger);
+
+    sut = new CommandHandler(mockApp, settings);
+  });
+
+  describe('commandString', () => {
+    it('should return commandListCommand trigger', () => {
+      expect(sut.commandString).toBe(commandTrigger);
+    });
+  });
+
+  describe('validateCommand', () => {
+    let inputText: string;
+    let startIndex: number;
+    const filterText = 'foo';
+
+    beforeAll(() => {
+      inputText = `${commandTrigger}${filterText}`;
+      startIndex = commandTrigger.length;
+    });
+
+    it('should validate parsed input', () => {
+      const inputInfo = new InputInfo(inputText);
+
+      sut.validateCommand(inputInfo, startIndex, filterText, null, null);
+      expect(inputInfo.mode).toBe(Mode.CommandList);
+
+      const commandListCmd = inputInfo.parsedCommand();
+      expect(commandListCmd.parsedInput).toBe(filterText);
+      expect(commandListCmd.isValidated).toBe(true);
+    });
+  });
+
+  describe('getSuggestions', () => {
+    test('with falsy input, it should return an empty array', () => {
+      const results = sut.getSuggestions(null);
+
+      expect(results).not.toBeNull();
+      expect(results).toBeInstanceOf(Array);
+      expect(results).toHaveLength(0);
+    });
+
+    test('with default settings, it should return suggestions for command list mode', () => {
+      const inputInfo = new InputInfo(commandTrigger);
+      const results = sut.getSuggestions(inputInfo);
+
+      expect(results).not.toBeNull();
+      expect(results).toBeInstanceOf(Array);
+
+      const resultCommandIds = new Set(results.map((sugg) => sugg.item.id));
+
+      expect(results).toHaveLength(mockCommands.length);
+      expect(mockCommands.every((command) => resultCommandIds.has(command.id))).toBe(
+        true,
+      );
+      expect(results.every((sugg) => sugg.type === 'command')).toBe(true);
+      expect(mockInternalPlugins.getPluginById).toHaveBeenCalledWith(
+        COMMAND_PALETTE_PLUGIN_ID,
+      );
+    });
+
+    test('with filter search term, it should return only matching suggestions for command list mode', () => {
+      const filterText = expectedCommandName;
+
+      const expectedItem = mockCommands.find(
+        (command) => command.name === expectedCommandName,
+      );
+
+      const mockPrepareQuery = jest.mocked<typeof prepareQuery>(prepareQuery);
+      mockPrepareQuery.mockReturnValueOnce(makePreparedQuery(filterText));
+
+      const mockFuzzySearch = jest.mocked<typeof fuzzySearch>(fuzzySearch);
+
+      mockFuzzySearch.mockImplementation((_q, text: string) => {
+        const match = makeFuzzyMatch();
+        return text.startsWith(filterText) ? match : null;
+      });
+
+      const inputInfo = new InputInfo(`${commandTrigger}${filterText}`);
+      const results = sut.getSuggestions(inputInfo);
+
+      expect(results).toBeInstanceOf(Array);
+      expect(results).toHaveLength(1);
+
+      const onlyResult = results[0];
+      expect(onlyResult).toHaveProperty('type', 'command');
+      expect(onlyResult.item.id).toBe(expectedItem.id);
+      expect(onlyResult.item.name).toBe(expectedItem.name);
+
+      expect(mockFuzzySearch).toHaveBeenCalled();
+      expect(mockPrepareQuery).toHaveBeenCalled();
+      expect(mockInternalPlugins.getPluginById).toHaveBeenCalled();
+
+      mockFuzzySearch.mockReset();
+    });
+  });
+
+  describe('renderSuggestion', () => {
+    it('should not throw an error with a null suggestion', () => {
+      expect(() => sut.renderSuggestion(null, null)).not.toThrow();
+    });
+
+    it('should render a suggestion with match offsets', () => {
+      const mockParentEl = mock<HTMLElement>();
+      const mockRenderResults = jest.mocked<typeof renderResults>(renderResults);
+
+      const match = makeFuzzyMatch();
+      const item = mockCommands[0];
+
+      const sugg = mock<CommandSuggestion>({ item, match });
+      sut.renderSuggestion(sugg, mockParentEl);
+
+      expect(mockRenderResults).toHaveBeenCalledWith(mockParentEl, item.name, match);
+    });
+  });
+
+  describe('onChooseSuggestion', () => {
+    it('should not throw an error with a null suggestion', () => {
+      expect(() => sut.onChooseSuggestion(null)).not.toThrow();
+    });
+
+    it('should tell the app to execute the command with the chosen ID', () => {
+      const match = makeFuzzyMatch();
+      const item = mockCommands[0];
+
+      const sugg = mock<CommandSuggestion>({ item, match });
+
+      sut.onChooseSuggestion(sugg);
+
+      expect(mockInternalPlugins.getPluginById).toHaveBeenCalled();
+      expect(mockApp.commands.executeCommandById).toHaveBeenCalledWith(item.id);
+    });
+  });
+
+  describe('getItems', () => {
+    let oldCommands: Command[];
+    let oldPinnedCommandIds: string[] | null;
+
+    beforeAll(() => {
+      oldCommands = mockCommands;
+      oldPinnedCommandIds = mockCommandPalettePluginInstance.options.pinned;
+    });
+
+    afterAll(() => {
+      mockCommands = oldCommands;
+      mockCommandPalettePluginInstance.options.pinned = oldPinnedCommandIds;
+    });
+
+    it('should order commands by name', () => {
+      mockCommands = [
+        makeCommandItem({ name: 'Command C' }),
+        makeCommandItem({ name: 'Command B' }),
+        makeCommandItem({ name: 'Command A' }),
+        makeCommandItem({ name: 'Command D' }),
+        makeCommandItem({ name: 'Command C' }),
+      ];
+
+      const results = sut.getItems();
+      expect(results).toHaveLength(5);
+      expect(results[0].name).toBe('Command A');
+      expect(results[1].name).toBe('Command B');
+      expect(results[2].name).toBe('Command C');
+      expect(results[3].name).toBe('Command C');
+      expect(results[4].name).toBe('Command D');
+    });
+
+    it('should order pinned commands first', () => {
+      mockCommands = [
+        makeCommandItem({ name: 'Command B' }),
+        makeCommandItem({ name: 'Command A' }),
+        makeCommandItem({ name: 'Command Pinned 1', id: 'pinned:command1' }),
+        makeCommandItem({ name: 'Command Pinned 2', id: 'pinned:command2' }),
+      ];
+      mockCommandPalettePluginInstance.options.pinned = [
+        'pinned:command1',
+        'pinned:command2',
+      ];
+
+      const results = sut.getItems();
+      expect(results).toHaveLength(4);
+      expect(results[0].name).toBe('Command Pinned 1');
+      expect(results[1].name).toBe('Command Pinned 2');
+      expect(results[2].name).toBe('Command A');
+      expect(results[3].name).toBe('Command B');
+    });
+  });
+});

--- a/src/Handlers/commandHandler.ts
+++ b/src/Handlers/commandHandler.ts
@@ -1,0 +1,131 @@
+import { getInternalPluginById } from 'src/utils';
+import { InputInfo } from 'src/switcherPlus';
+import { SwitcherPlusSettings } from 'src/settings/';
+import { AnySuggestion, Handler, Mode, CommandSuggestion } from 'src/types';
+import {
+  App,
+  InstalledPlugin,
+  SearchResult,
+  sortSearchResults,
+  WorkspaceLeaf,
+  fuzzySearch,
+  renderResults,
+  CommandPalettePluginInstance,
+  Command,
+} from 'obsidian';
+
+export const COMMAND_PALETTE_PLUGIN_ID = 'command-palette';
+
+export class CommandHandler implements Handler<CommandSuggestion> {
+  get commandString(): string {
+    return this.settings?.commandListCommand;
+  }
+
+  constructor(private app: App, private settings: SwitcherPlusSettings) {}
+  validateCommand(
+    inputInfo: InputInfo,
+    index: number,
+    filterText: string,
+    _activeSuggestion: AnySuggestion,
+    _activeLeaf: WorkspaceLeaf,
+  ): void {
+    inputInfo.mode = Mode.CommandList;
+
+    const commandCmd = inputInfo.parsedCommand(Mode.CommandList);
+    commandCmd.index = index;
+    commandCmd.parsedInput = filterText;
+    commandCmd.isValidated = true;
+  }
+
+  getSuggestions(inputInfo: InputInfo): CommandSuggestion[] {
+    const suggestions: CommandSuggestion[] = [];
+
+    if (inputInfo) {
+      inputInfo.buildSearchQuery();
+      const { hasSearchTerm, prepQuery } = inputInfo.searchQuery;
+      const itemsInfo = this.getItems();
+
+      itemsInfo.forEach((item) => {
+        let shouldPush = true;
+        let match: SearchResult = null;
+
+        if (hasSearchTerm) {
+          match = fuzzySearch(prepQuery, item.name);
+          shouldPush = !!match;
+        }
+
+        if (shouldPush) {
+          suggestions.push({
+            type: 'command',
+            item,
+            match,
+          });
+        }
+      });
+
+      if (hasSearchTerm) {
+        sortSearchResults(suggestions);
+      }
+    }
+
+    return suggestions;
+  }
+
+  renderSuggestion(sugg: CommandSuggestion, parentEl: HTMLElement): void {
+    if (sugg) {
+      renderResults(parentEl, sugg.item.name, sugg.match);
+    }
+  }
+
+  onChooseSuggestion(sugg: CommandSuggestion): void {
+    if (sugg) {
+      const { item } = sugg;
+      this.app.commands.executeCommandById(item.id);
+    }
+  }
+
+  getItems(): Command[] {
+    // Sort commands by their name
+    const items: Command[] = this.app.commands.listCommands().sort((a, b) => {
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    });
+
+    // Pinned commands should be at the top (if any)
+    if (
+      this.isCommandPalettePluginEnabled() &&
+      this.getCommandPalettePluginInstance()?.options.pinned?.length > 0
+    ) {
+      const pinnedCommandIds = this.getCommandPalettePluginInstance().options.pinned;
+
+      // We're gonna find the pinned command in `items` and move it to the beginning
+      // Therefore we need to perform "for each right"
+      for (let i = pinnedCommandIds.length - 1; i >= 0; i--) {
+        const commandId = pinnedCommandIds[i];
+        const commandIndex = items.findIndex((c) => c.id === commandId);
+        if (commandIndex > -1) {
+          const command = items[commandIndex];
+          items.splice(commandIndex, 1);
+          items.unshift(command);
+        }
+      }
+    }
+
+    return items;
+  }
+
+  private isCommandPalettePluginEnabled(): boolean {
+    const plugin = this.getCommandPalettePlugin();
+    return plugin?.enabled;
+  }
+
+  private getCommandPalettePlugin(): InstalledPlugin {
+    return getInternalPluginById(this.app, COMMAND_PALETTE_PLUGIN_ID);
+  }
+
+  private getCommandPalettePluginInstance(): CommandPalettePluginInstance {
+    const commandPalettePlugin = this.getCommandPalettePlugin();
+    return commandPalettePlugin?.instance as CommandPalettePluginInstance;
+  }
+}

--- a/src/Handlers/index.ts
+++ b/src/Handlers/index.ts
@@ -3,3 +3,4 @@ export * from './headingsHandler';
 export * from './editorHandler';
 export * from './symbolHandler';
 export * from './starredHandler';
+export * from './commandHandler';

--- a/src/Handlers/symbolHandler.ts
+++ b/src/Handlers/symbolHandler.ts
@@ -41,6 +41,7 @@ import {
   isUnresolvedSuggestion,
   isWorkspaceSuggestion,
   openFileInLeaf,
+  isCommandSuggestion,
 } from 'src/utils';
 import { SwitcherPlusSettings } from 'src/settings';
 import { InputInfo, SymbolParsedCommand } from 'src/switcherPlus';
@@ -234,7 +235,8 @@ export class SymbolHandler implements Handler<SymbolSuggestion> {
       suggestion &&
       !isSymbolSuggestion(suggestion) &&
       !isUnresolvedSuggestion(suggestion) &&
-      !isWorkspaceSuggestion(suggestion);
+      !isWorkspaceSuggestion(suggestion) &&
+      !isCommandSuggestion(suggestion);
 
     if (isEditorSuggestion(suggestion)) {
       // note: this leaf could be a reference view, which is not usable for

--- a/src/__fixtures__/commandMode.fixture.ts
+++ b/src/__fixtures__/commandMode.fixture.ts
@@ -1,0 +1,11 @@
+import { Command } from 'obsidian';
+import { Chance } from 'chance';
+
+const chance = new Chance();
+
+export function makeCommandItem(options?: { id?: string; name?: string }): Command {
+  return {
+    id: options?.id ?? chance.word(),
+    name: options?.name ?? chance.word(),
+  };
+}

--- a/src/__fixtures__/index.ts
+++ b/src/__fixtures__/index.ts
@@ -4,3 +4,4 @@ export * from './fixtureUtils';
 export * from './inputText.fixture';
 export * from './modeTrigger.fixture';
 export * from './starredMode.fixture';
+export * from './commandMode.fixture';

--- a/src/__fixtures__/inputText.fixture.ts
+++ b/src/__fixtures__/inputText.fixture.ts
@@ -5,6 +5,7 @@ import {
   workspaceTrigger,
   headingsTrigger,
   starredTrigger,
+  commandTrigger,
 } from './modeTrigger.fixture';
 
 interface InputExpectation {
@@ -64,6 +65,13 @@ function starredExpectation(
   expectedParsedInput?: string,
 ): InputExpectation {
   return makeInputExpectation(input, Mode.StarredList, expectedParsedInput);
+}
+
+function commandExpectation(
+  input: string,
+  expectedParsedInput?: string,
+): InputExpectation {
+  return makeInputExpectation(input, Mode.CommandList, expectedParsedInput);
 }
 
 interface InputExpectationStandard {
@@ -369,6 +377,37 @@ export const starredPrefixOnlyInputFixture = [
   ),
   starredExpectation(
     `${starredTrigger}bar ${symbolTrigger} foo`,
+    `bar ${symbolTrigger} foo`,
+  ),
+];
+
+// Used for command mode tests
+export const commandPrefixOnlyInputFixture = [
+  commandExpectation(`${commandTrigger}`, ''),
+  commandExpectation(`${commandTrigger}test string`, 'test string'),
+  commandExpectation(`${commandTrigger}${symbolTrigger}`, `${symbolTrigger}`),
+  commandExpectation(`${commandTrigger} ${symbolTrigger}`, ` ${symbolTrigger}`),
+  commandExpectation(`${commandTrigger}${symbolTrigger}  `, `${symbolTrigger}  `),
+  commandExpectation(`${commandTrigger}${symbolTrigger}foo`, `${symbolTrigger}foo`),
+  commandExpectation(`${commandTrigger}${symbolTrigger} fooo`, `${symbolTrigger} fooo`),
+  commandExpectation(`${commandTrigger}bar${symbolTrigger}`, `bar${symbolTrigger}`),
+  commandExpectation(`${commandTrigger}bar${editorTrigger}  `, `bar${editorTrigger}  `),
+  commandExpectation(`${commandTrigger}bar ${symbolTrigger}`, `bar ${symbolTrigger}`),
+  commandExpectation(
+    `${commandTrigger}bar ${symbolTrigger}   `,
+    `bar ${symbolTrigger}   `,
+  ),
+  commandExpectation(`${commandTrigger}bar${symbolTrigger}foo`, `bar${symbolTrigger}foo`),
+  commandExpectation(
+    `${commandTrigger}bar${symbolTrigger} foo`,
+    `bar${symbolTrigger} foo`,
+  ),
+  commandExpectation(
+    `${commandTrigger}bar ${symbolTrigger}foo  `,
+    `bar ${symbolTrigger}foo  `,
+  ),
+  commandExpectation(
+    `${commandTrigger}bar ${symbolTrigger} foo`,
     `bar ${symbolTrigger} foo`,
   ),
 ];

--- a/src/__fixtures__/modeTrigger.fixture.ts
+++ b/src/__fixtures__/modeTrigger.fixture.ts
@@ -3,3 +3,4 @@ export const symbolTrigger = '<s-trigger>';
 export const workspaceTrigger = '<w-trigger>';
 export const headingsTrigger = '<h-trigger>';
 export const starredTrigger = '<*-trigger>';
+export const commandTrigger = '<c-trigger>';

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,11 @@ export default class SwitcherPlusPlugin extends Plugin {
       'Open in Starred Mode',
       Mode.StarredList,
     );
+    this.registerCommand(
+      'switcher-plus:open-commands',
+      'Open in Commands Mode',
+      Mode.CommandList,
+    );
   }
 
   registerCommand(id: string, name: string, mode: Mode): void {

--- a/src/settings/__tests__/commandListSettingsTabSection.test.ts
+++ b/src/settings/__tests__/commandListSettingsTabSection.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SwitcherPlusSettings } from '../switcherPlusSettings';
+import { CommandListSettingTabSection } from '../commandListSettingsTabSection';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { App, InternalPlugins, PluginSettingTab, Setting, TextComponent } from 'obsidian';
+import { commandTrigger } from '@fixtures';
+
+describe('commandListSettingTabSection', () => {
+  let mockApp: MockProxy<App>;
+  let mockPluginSettingTab: MockProxy<PluginSettingTab>;
+  let mockSettings: MockProxy<SwitcherPlusSettings>;
+  let mockContainerEl: MockProxy<HTMLElement>;
+  let sut: CommandListSettingTabSection;
+  let createSettingSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    mockApp = mock<App>({ internalPlugins: mock<InternalPlugins>() });
+    mockSettings = mock<SwitcherPlusSettings>({
+      commandListPlaceholderText: commandTrigger,
+      commandListCommand: commandTrigger,
+    });
+  });
+
+  beforeEach(() => {
+    mockContainerEl = mock<HTMLElement>();
+    mockPluginSettingTab = mock<PluginSettingTab>({ containerEl: mockContainerEl });
+    sut = new CommandListSettingTabSection(mockApp, mockPluginSettingTab, mockSettings);
+    createSettingSpy = jest.spyOn(sut, 'createSetting');
+  });
+
+  afterEach(() => {
+    createSettingSpy.mockRestore();
+  });
+
+  it('should display a header for the section', () => {
+    createSettingSpy.mockReturnValueOnce(mock<Setting>());
+
+    sut.display(mockContainerEl);
+
+    expect(mockContainerEl.createEl).toHaveBeenCalledWith(
+      'h2',
+      expect.objectContaining({ text: 'Command List Mode Settings' }),
+    );
+  });
+
+  it('should load setting for mode trigger', () => {
+    const textComp = new TextComponent(mockContainerEl);
+    const setValueSpy = jest.spyOn(textComp, 'setValue');
+    const setPlaceholderSpy = jest.spyOn(textComp, 'setPlaceholder');
+    const setting = mock<Setting>();
+
+    setting.addText.mockImplementationOnce((cb: (component: TextComponent) => any) => {
+      cb(textComp);
+      return setting;
+    });
+
+    createSettingSpy.mockReturnValueOnce(setting);
+
+    sut.display(mockContainerEl);
+
+    expect(setValueSpy).toHaveBeenCalledWith(mockSettings.commandListCommand);
+    expect(setPlaceholderSpy).toHaveBeenCalledWith(
+      mockSettings.commandListPlaceholderText,
+    );
+
+    setValueSpy.mockRestore();
+    setPlaceholderSpy.mockRestore();
+  });
+
+  it('should save modified settings', () => {
+    const initialCommandVal = mockSettings.commandListCommand;
+    const finalCommandVal = 'foo';
+    const textComp = new TextComponent(mockContainerEl);
+    const setting = mock<Setting>();
+
+    setting.addText.mockImplementationOnce((cb: (component: TextComponent) => any) => {
+      cb(textComp);
+      return setting;
+    });
+
+    createSettingSpy.mockReturnValueOnce(setting);
+
+    sut.display(mockContainerEl);
+    textComp.setValue(finalCommandVal); // change the setting here
+
+    expect(initialCommandVal).toBe(commandTrigger);
+    expect(mockSettings.save).toHaveBeenCalled();
+    expect(mockSettings.commandListCommand).toBe(finalCommandVal);
+
+    mockSettings.commandListCommand = commandTrigger;
+  });
+
+  it('should fallback to the default trigger when an empty string is set for the trigger', () => {
+    const initialCommandVal = mockSettings.commandListCommand;
+    const textComp = new TextComponent(mockContainerEl);
+    const setting = mock<Setting>();
+
+    setting.addText.mockImplementationOnce((cb: (component: TextComponent) => any) => {
+      cb(textComp);
+      return setting;
+    });
+
+    createSettingSpy.mockReturnValueOnce(setting);
+
+    sut.display(mockContainerEl);
+    textComp.setValue(''); // change the setting here
+
+    expect(initialCommandVal).toBe(commandTrigger);
+    expect(mockSettings.save).toHaveBeenCalled();
+    expect(mockSettings.commandListCommand).toBe(commandTrigger);
+
+    mockSettings.commandListCommand = commandTrigger;
+  });
+});

--- a/src/settings/__tests__/switcherPlusSettings.test.ts
+++ b/src/settings/__tests__/switcherPlusSettings.test.ts
@@ -33,11 +33,12 @@ function transientSettingsData(useDefault: boolean): SettingsData {
     symbolListCommand: '@',
     workspaceListCommand: '+',
     headingsListCommand: '#',
+    starredListCommand: "'",
+    commandListCommand: '>',
     strictHeadingsOnly: false,
     searchAllHeadings: true,
     limit: 50,
     selectNearestHeading: true,
-    starredListCommand: "'",
     excludeLinkSubTypes: LinkType.None,
     includeSidePanelViewTypes: sidePanelOptions,
     excludeFolders: [],
@@ -51,11 +52,12 @@ function transientSettingsData(useDefault: boolean): SettingsData {
     data.symbolListCommand = chance.word();
     data.workspaceListCommand = chance.word();
     data.headingsListCommand = chance.word();
+    data.starredListCommand = chance.word();
+    data.commandListCommand = chance.word();
     data.strictHeadingsOnly = chance.bool();
     data.searchAllHeadings = chance.bool();
     data.limit = chance.integer();
     data.selectNearestHeading = chance.bool();
-    data.starredListCommand = chance.word();
     data.excludeLinkSubTypes = LinkType.Block;
 
     data.includeSidePanelViewTypes = [
@@ -104,6 +106,7 @@ describe('SwitcherPlusSettings', () => {
     expect(sut.workspaceListPlaceholderText).toBe(defaults.workspaceListCommand);
     expect(sut.headingsListPlaceholderText).toBe(defaults.headingsListCommand);
     expect(sut.starredListPlaceholderText).toBe(defaults.starredListCommand);
+    expect(sut.commandListPlaceholderText).toBe(defaults.commandListCommand);
     expect(sut.includeSidePanelViewTypesPlaceholder).toBe(
       defaults.includeSidePanelViewTypes.join('\n'),
     );
@@ -133,6 +136,7 @@ describe('SwitcherPlusSettings', () => {
     sut.workspaceListCommand = settings.workspaceListCommand;
     sut.headingsListCommand = settings.headingsListCommand;
     sut.starredListCommand = settings.starredListCommand;
+    sut.commandListCommand = settings.commandListCommand;
     sut.strictHeadingsOnly = settings.strictHeadingsOnly;
     sut.searchAllHeadings = settings.searchAllHeadings;
     sut.includeSidePanelViewTypes = settings.includeSidePanelViewTypes;

--- a/src/settings/commandListSettingsTabSection.ts
+++ b/src/settings/commandListSettingsTabSection.ts
@@ -1,0 +1,31 @@
+import { SwitcherPlusSettings } from './switcherPlusSettings';
+import { SettingsTabSection } from './settingsTabSection';
+
+export class CommandListSettingTabSection extends SettingsTabSection {
+  display(containerEl: HTMLElement): void {
+    containerEl.createEl('h2', { text: 'Command List Mode Settings' });
+
+    this.setCommandListCommand(containerEl, this.settings);
+  }
+
+  private setCommandListCommand(
+    containerEl: HTMLElement,
+    settings: SwitcherPlusSettings,
+  ): void {
+    this.createSetting(
+      containerEl,
+      'Command list mode trigger',
+      'Character that will trigger command list mode in the switcher',
+    ).addText((text) =>
+      text
+        .setPlaceholder(settings.commandListPlaceholderText)
+        .setValue(settings.commandListCommand)
+        .onChange((value) => {
+          const val = value.length ? value : settings.commandListPlaceholderText;
+
+          settings.commandListCommand = val;
+          settings.save();
+        }),
+    );
+  }
+}

--- a/src/settings/switcherPlusSettingTab.ts
+++ b/src/settings/switcherPlusSettingTab.ts
@@ -1,4 +1,5 @@
 import { StarredSettingTabSection } from './starredSettingsTabSection';
+import { CommandListSettingTabSection } from './commandListSettingsTabSection';
 import { App, Modal, PluginSettingTab, Setting } from 'obsidian';
 import { LinkType, SymbolType } from 'src/types';
 import { SwitcherPlusSettings } from 'src/settings';
@@ -23,8 +24,10 @@ export class SwitcherPlusSettingTab extends PluginSettingTab {
     this.setHeadingsModeSettingsGroup(containerEl, settings);
 
     const starredSection = new StarredSettingTabSection(this.app, this, settings);
-
     starredSection.display(containerEl);
+
+    const commandListSection = new CommandListSettingTabSection(this.app, this, settings);
+    commandListSection.display(containerEl);
   }
 
   private setEditorModeSettingsGroup(

--- a/src/settings/switcherPlusSettings.ts
+++ b/src/settings/switcherPlusSettings.ts
@@ -22,6 +22,7 @@ export class SwitcherPlusSettings {
       workspaceListCommand: '+',
       headingsListCommand: '#',
       starredListCommand: "'",
+      commandListCommand: '>',
       strictHeadingsOnly: false,
       searchAllHeadings: true,
       excludeViewTypes: ['empty'],
@@ -141,6 +142,18 @@ export class SwitcherPlusSettings {
 
   get starredListPlaceholderText(): string {
     return SwitcherPlusSettings.defaults.starredListCommand;
+  }
+
+  get commandListCommand(): string {
+    return this.data.commandListCommand;
+  }
+
+  set commandListCommand(value: string) {
+    this.data.commandListCommand = value;
+  }
+
+  get commandListPlaceholderText(): string {
+    return SwitcherPlusSettings.defaults.commandListCommand;
   }
 
   get strictHeadingsOnly(): boolean {

--- a/src/switcherPlus/inputInfo.ts
+++ b/src/switcherPlus/inputInfo.ts
@@ -40,6 +40,7 @@ export class InputInfo {
     pcs[Mode.WorkspaceList] = InputInfo.defaultParsedCommand;
     pcs[Mode.HeadingsList] = InputInfo.defaultParsedCommand;
     pcs[Mode.StarredList] = InputInfo.defaultParsedCommand;
+    pcs[Mode.CommandList] = InputInfo.defaultParsedCommand;
     this.parsedCommands = pcs;
   }
 

--- a/src/types/obsidian/index.d.ts
+++ b/src/types/obsidian/index.d.ts
@@ -24,6 +24,12 @@ declare module 'obsidian' {
     items: Array<StarredPluginItem>;
   }
 
+  export interface CommandPalettePluginInstance extends PluginInstance {
+    options: {
+      pinned?: Array<string>;
+    };
+  }
+
   export interface WorkspacesPluginInstance extends PluginInstance {
     workspaces: Record<string, unknown>;
     loadWorkspace(id: string): void;
@@ -58,6 +64,10 @@ declare module 'obsidian' {
   export interface App {
     internalPlugins: InternalPlugins;
     viewRegistry: ViewRegistry;
+    commands: {
+      listCommands(): Command[];
+      executeCommandById(id: string): boolean;
+    };
   }
 
   export interface Chooser<T> {

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -10,6 +10,7 @@ import {
   TagCache,
   TFile,
   WorkspaceLeaf,
+  Command,
 } from 'obsidian';
 import type { SuggestModal, StarredPluginItem } from 'obsidian';
 import type { InputInfo } from 'src/switcherPlus/inputInfo';
@@ -21,6 +22,7 @@ export enum Mode {
   WorkspaceList = 8,
   HeadingsList = 16,
   StarredList = 32,
+  CommandList = 64,
 }
 
 export enum SymbolType {
@@ -129,6 +131,10 @@ export interface UnresolvedSuggestion extends Omit<FuzzyMatch<string>, 'item'> {
   type: 'unresolved';
 }
 
+export interface CommandSuggestion extends FuzzyMatch<Command> {
+  type: 'command';
+}
+
 export type AnyExSuggestionPayload = WorkspaceLeaf | SymbolInfo | WorkspaceInfo;
 
 export type AnyExSuggestion =
@@ -136,7 +142,8 @@ export type AnyExSuggestion =
   | EditorSuggestion
   | WorkspaceSuggestion
   | HeadingSuggestion
-  | StarredSuggestion;
+  | StarredSuggestion
+  | CommandSuggestion;
 
 export type AnySystemSuggestion = FileSuggestion | AliasSuggestion | UnresolvedSuggestion;
 
@@ -159,6 +166,7 @@ export interface SettingsData {
   workspaceListCommand: string;
   headingsListCommand: string;
   starredListCommand: string;
+  commandListCommand: string;
   strictHeadingsOnly: boolean;
   searchAllHeadings: boolean;
   excludeViewTypes: Array<string>;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -21,6 +21,7 @@ import {
   AnyExSuggestion,
   LinkType,
   StarredSuggestion,
+  CommandSuggestion,
 } from 'src/types';
 
 export function isOfType<T>(
@@ -58,6 +59,10 @@ export function isHeadingSuggestion(obj: unknown): obj is HeadingSuggestion {
 
 export function isStarredSuggestion(obj: unknown): obj is StarredSuggestion {
   return isOfType<StarredSuggestion>(obj, 'type', 'starred');
+}
+
+export function isCommandSuggestion(obj: unknown): obj is CommandSuggestion {
+  return isOfType<CommandSuggestion>(obj, 'type', 'command');
 }
 
 export function isFileSuggestion(obj: unknown): obj is FileSuggestion {


### PR DESCRIPTION
First, I want to thank you for developing this plugin. I’m a heavy VS Code user, and this plugin is one of the reasons that Obsidian feels like home. I’m a huge fan of VS Code’s `cmd + p` shortcut, having just one prompt for file navigation, jumping to symbols, and running commands. The only missing piece of Quick Switcher++ for me is running commands. I don’t want to have another dedicated keyboard shortcut for the command palette.

This PR is my attempt to implement “command list" mode triggered by `>` character just like in VS Code. Looking for your feedback!

https://user-images.githubusercontent.com/1475786/169143716-1cb1ec70-21c4-4925-a133-a11e715ed891.mov


