### PR TITLE
feat: implement preserve last input

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ When the Related Items command is triggered for a selected input suggestion/file
 | Override Standard mode behavior | **Enabled**: Switcher++ will change the default Obsidian builtin Switcher functionality (Standard mode) to inject custom behavior. Custom behavior includes features like enhance rendering of suggestion items to display additional information, special path display handling, and tab navigation features.<br />**Disabled**: No changes are made to the default Obsidian builtin functionality (Standard Mode). | enabled |
 | Show indicator icons | **Enabled**: Display icons to indicate that an item is recent, starred, etc... | enabled |
 | Result priority adjustments | **Enabled**: Artificially increase the match score of the specified item types by a fixed percentage so they appear higher in the results list. See the list of [result types](/src/settings/generalSettingsTabSection.ts#L6) that can be prioritized. Note that the adjustments are independent of each other, e.g. if adjustments are specified for both `Starred items` and `Open items` a result for a file that is open and starred will receive both adjustments.<br />**Disabled** result match scores are not adjusted. | disabled |
+| Restore previous input in Command Mode | **Enabled**: restore previous command mode input when launched via global command hotkey | disabled |
+| Restore previous input | **Enabled**: restore previous switcher input when launched via global command hotkey | disabled |
 
 ## Global Commands for Hotkeys
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "bundle": "rollup --bundleConfigAsCjs -c rollup.config.js",
     "package-plugin": "cp -a ./styles.css ./manifest.json ./versions.json ./dist/darlal-switcher-plus",
-    "build": "run-s lint bundle package-plugin",
-    "build:watch": "onchange 'src/**/*.ts' -- npm run build",
+    "build": "run-s lint build:fast",
+    "build:fast": "run-s bundle package-plugin",
+    "build:watch": "onchange 'src/**/*.ts' -- npm run build:fast",
     "ci": "BUILD=production run-s lint test bundle package-plugin",
     "lint": "eslint '*/**/*.{js,ts}'",
     "test": "jest",

--- a/src/settings/__tests__/switcherPlusSettings.test.ts
+++ b/src/settings/__tests__/switcherPlusSettings.test.ts
@@ -74,6 +74,7 @@ function transientSettingsData(useDefault: boolean): SettingsData {
       alias: 0,
       h1: 0,
     },
+    preserveLastInput: false,
   };
 
   if (!useDefault) {

--- a/src/settings/__tests__/switcherPlusSettings.test.ts
+++ b/src/settings/__tests__/switcherPlusSettings.test.ts
@@ -75,6 +75,7 @@ function transientSettingsData(useDefault: boolean): SettingsData {
       h1: 0,
     },
     preserveCommandPaletteLastInput: false,
+    preserveQuickSwitcherLastInput: false,
   };
 
   if (!useDefault) {

--- a/src/settings/__tests__/switcherPlusSettings.test.ts
+++ b/src/settings/__tests__/switcherPlusSettings.test.ts
@@ -74,7 +74,7 @@ function transientSettingsData(useDefault: boolean): SettingsData {
       alias: 0,
       h1: 0,
     },
-    preserveLastInput: false,
+    preserveCommandPaletteLastInput: false,
   };
 
   if (!useDefault) {

--- a/src/settings/commandListSettingsTabSection.ts
+++ b/src/settings/commandListSettingsTabSection.ts
@@ -14,12 +14,5 @@ export class CommandListSettingsTabSection extends SettingsTabSection {
       'commandListCommand',
       config.commandListPlaceholderText,
     );
-    this.addToggleSetting(
-      containerEl,
-      'Preserve Command Palette last input',
-      'Controls whether the last typed input to the Command Palette should be restored when opening it the next time.',
-      config.preserveCommandPaletteLastInput,
-      'preserveCommandPaletteLastInput',
-    );
   }
 }

--- a/src/settings/commandListSettingsTabSection.ts
+++ b/src/settings/commandListSettingsTabSection.ts
@@ -16,10 +16,10 @@ export class CommandListSettingsTabSection extends SettingsTabSection {
     );
     this.addToggleSetting(
       containerEl,
-      'Preserve last input',
-      'Controls whether the last typed input to Quick Switcher should be restored when opening it the next time.',
-      config.preserveLastInput,
-      'preserveLastInput',
+      'Preserve Command Palette last input',
+      'Controls whether the last typed input to the Command Palette should be restored when opening it the next time.',
+      config.preserveCommandPaletteLastInput,
+      'preserveCommandPaletteLastInput',
     );
   }
 }

--- a/src/settings/commandListSettingsTabSection.ts
+++ b/src/settings/commandListSettingsTabSection.ts
@@ -14,5 +14,12 @@ export class CommandListSettingsTabSection extends SettingsTabSection {
       'commandListCommand',
       config.commandListPlaceholderText,
     );
+    this.addToggleSetting(
+      containerEl,
+      'Preserve last input',
+      'Controls whether the last typed input to Quick Switcher should be restored when opening it the next time.',
+      config.preserveLastInput,
+      'preserveLastInput',
+    );
   }
 }

--- a/src/settings/generalSettingsTabSection.ts
+++ b/src/settings/generalSettingsTabSection.ts
@@ -61,15 +61,15 @@ export class GeneralSettingsTabSection extends SettingsTabSection {
     this.showMatchPriorityAdjustments(containerEl, config);
     this.addToggleSetting(
       containerEl,
-      'Preserve Command Palette last input',
-      'Controls whether the last typed input to the Command Palette should be restored when opening it the next time.',
+      'Restore previous input in Command Mode',
+      'When enabled, restore the last typed input in Command Mode when launched via global command hotkey.',
       config.preserveCommandPaletteLastInput,
       'preserveCommandPaletteLastInput',
     );
     this.addToggleSetting(
       containerEl,
-      'Preserve Quick Switcher last input',
-      'Controls whether the last typed input to Quick Switcher should be restored when opening it the next time.',
+      'Restore previous input',
+      'When enabled, restore the last typed input when launched via global command hotkey.',
       config.preserveQuickSwitcherLastInput,
       'preserveQuickSwitcherLastInput',
     );

--- a/src/settings/generalSettingsTabSection.ts
+++ b/src/settings/generalSettingsTabSection.ts
@@ -59,6 +59,20 @@ export class GeneralSettingsTabSection extends SettingsTabSection {
     );
 
     this.showMatchPriorityAdjustments(containerEl, config);
+    this.addToggleSetting(
+      containerEl,
+      'Preserve Command Palette last input',
+      'Controls whether the last typed input to the Command Palette should be restored when opening it the next time.',
+      config.preserveCommandPaletteLastInput,
+      'preserveCommandPaletteLastInput',
+    );
+    this.addToggleSetting(
+      containerEl,
+      'Preserve Quick Switcher last input',
+      'Controls whether the last typed input to Quick Switcher should be restored when opening it the next time.',
+      config.preserveQuickSwitcherLastInput,
+      'preserveQuickSwitcherLastInput',
+    );
   }
 
   setPathDisplayFormat(containerEl: HTMLElement, config: SwitcherPlusSettings): void {

--- a/src/settings/switcherPlusSettings.ts
+++ b/src/settings/switcherPlusSettings.ts
@@ -64,7 +64,7 @@ export class SwitcherPlusSettings {
         alias: 0,
         h1: 0,
       },
-      preserveLastInput: false,
+      preserveCommandPaletteLastInput: false,
     };
   }
 
@@ -375,12 +375,12 @@ export class SwitcherPlusSettings {
     this.data.matchPriorityAdjustments = value;
   }
 
-  get preserveLastInput() {
-    return this.data.preserveLastInput;
+  get preserveCommandPaletteLastInput() {
+    return this.data.preserveCommandPaletteLastInput;
   }
 
-  set preserveLastInput(value: boolean) {
-    this.data.preserveLastInput = value;
+  set preserveCommandPaletteLastInput(value: boolean) {
+    this.data.preserveCommandPaletteLastInput = value;
   }
 
   constructor(private plugin: SwitcherPlusPlugin) {

--- a/src/settings/switcherPlusSettings.ts
+++ b/src/settings/switcherPlusSettings.ts
@@ -65,6 +65,7 @@ export class SwitcherPlusSettings {
         h1: 0,
       },
       preserveCommandPaletteLastInput: false,
+      preserveQuickSwitcherLastInput: false,
     };
   }
 
@@ -381,6 +382,14 @@ export class SwitcherPlusSettings {
 
   set preserveCommandPaletteLastInput(value: boolean) {
     this.data.preserveCommandPaletteLastInput = value;
+  }
+
+  get preserveQuickSwitcherLastInput() {
+    return this.data.preserveQuickSwitcherLastInput;
+  }
+
+  set preserveQuickSwitcherLastInput(value: boolean) {
+    this.data.preserveQuickSwitcherLastInput = value;
   }
 
   constructor(private plugin: SwitcherPlusPlugin) {

--- a/src/settings/switcherPlusSettings.ts
+++ b/src/settings/switcherPlusSettings.ts
@@ -64,6 +64,7 @@ export class SwitcherPlusSettings {
         alias: 0,
         h1: 0,
       },
+      preserveLastInput: false,
     };
   }
 
@@ -372,6 +373,14 @@ export class SwitcherPlusSettings {
 
   set matchPriorityAdjustments(value: Record<string, number>) {
     this.data.matchPriorityAdjustments = value;
+  }
+
+  get preserveLastInput() {
+    return this.data.preserveLastInput;
+  }
+
+  set preserveLastInput(value: boolean) {
+    this.data.preserveLastInput = value;
   }
 
   constructor(private plugin: SwitcherPlusPlugin) {

--- a/src/switcherPlus/__tests__/modeHandler.test.ts
+++ b/src/switcherPlus/__tests__/modeHandler.test.ts
@@ -272,10 +272,7 @@ describe('modeHandler', () => {
         sut.updateSuggestions(expectToRestore, mockChooser, null);
 
         mockInputEl.value = '';
-        mockInputEl.selectionStart = 0;
-        mockInputEl.selectionEnd = 0;
         sut.setSessionOpenMode(Mode.CommandList, null);
-
         sut.insertSessionOpenModeOrLastInputString(mockInputEl);
 
         expect(mockInputEl).toHaveProperty('value', expectToRestore);
@@ -285,11 +282,12 @@ describe('modeHandler', () => {
           commandTrigger.length,
           expectToRestore.length,
         );
+
         // if we open another mode, it wouldn't restore last input
         mockInputEl.value = '';
         sut.setSessionOpenMode(Mode.SymbolList, null);
-
         sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+
         expect(mockInputEl).toHaveProperty('value', symbolTrigger);
 
         mockSettings.preserveCommandPaletteLastInput = false;
@@ -304,7 +302,6 @@ describe('modeHandler', () => {
 
         mockInputEl.value = '';
         sut.setSessionOpenMode(Mode.CommandList, null);
-
         sut.insertSessionOpenModeOrLastInputString(mockInputEl);
 
         expect(mockInputEl).toHaveProperty('value', commandTrigger);
@@ -314,17 +311,17 @@ describe('modeHandler', () => {
         mockSettings.preserveCommandPaletteLastInput = false;
         mockSettings.preserveQuickSwitcherLastInput = true;
 
+        // will not save, because `preserveCommandPaletteLastInput` is false.
         sut.updateSuggestions(`${commandTrigger} any text`, mockChooser, null);
 
         mockInputEl.value = '';
         sut.setSessionOpenMode(Mode.CommandList, null);
-
         sut.insertSessionOpenModeOrLastInputString(mockInputEl);
 
         // will not save command last input if the configuration is falsy.
         expect(mockInputEl).toHaveProperty('value', commandTrigger);
 
-        // save first input
+        // save input
         const expectToRestore = `${editorTrigger} hello`;
         sut.updateSuggestions(expectToRestore, mockChooser, null);
 

--- a/src/switcherPlus/__tests__/modeHandler.test.ts
+++ b/src/switcherPlus/__tests__/modeHandler.test.ts
@@ -254,7 +254,7 @@ describe('modeHandler', () => {
       const mockChooser = mock<Chooser<AnySuggestion>>();
       const mockInputEl = mock<HTMLInputElement>();
 
-      let getSuggestionSpy: jest.SpyInstance<any, any, any>;
+      let getSuggestionSpy: jest.SpyInstance;
       beforeAll(() => {
         sut = new ModeHandler(mockApp, mockSettings, mockKeymap);
         getSuggestionSpy = jest
@@ -262,7 +262,7 @@ describe('modeHandler', () => {
           .mockReturnValue();
       });
       afterAll(() => {
-        getSuggestionSpy.mockClear();
+        getSuggestionSpy.mockRestore();
       });
       it('should restore the command string into the input element', () => {
         mockSettings.preserveCommandPaletteLastInput = true;

--- a/src/switcherPlus/__tests__/modeHandler.test.ts
+++ b/src/switcherPlus/__tests__/modeHandler.test.ts
@@ -228,14 +228,14 @@ describe('modeHandler', () => {
       );
     });
 
-    describe('insertSessionOpenModeCommandString', () => {
+    describe('insertSessionOpenModeOrLastInputString', () => {
       const mockInputEl = mock<HTMLInputElement>();
 
       it('should insert the command string into the input element', () => {
         mockInputEl.value = '';
         sut.setSessionOpenMode(Mode.EditorList, null);
 
-        sut.insertSessionOpenModeCommandString(mockInputEl);
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
 
         expect(mockInputEl).toHaveProperty('value', editorTrigger);
       });
@@ -244,9 +244,97 @@ describe('modeHandler', () => {
         mockInputEl.value = '';
         sut.setSessionOpenMode(Mode.Standard, null);
 
-        sut.insertSessionOpenModeCommandString(mockInputEl);
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
 
         expect(mockInputEl).toHaveProperty('value', '');
+      });
+    });
+    describe('insertSessionOpenModeOrLastInputString should restore last text', () => {
+      const mockKeymap = mock<SwitcherPlusKeymap>();
+      const mockChooser = mock<Chooser<AnySuggestion>>();
+      const mockInputEl = mock<HTMLInputElement>();
+
+      let getSuggestionSpy: jest.SpyInstance<any, any, any>;
+      beforeAll(() => {
+        sut = new ModeHandler(mockApp, mockSettings, mockKeymap);
+        getSuggestionSpy = jest
+          .spyOn(ModeHandler.prototype, 'getSuggestions')
+          .mockReturnValue();
+      });
+      afterAll(() => {
+        getSuggestionSpy.mockClear();
+      });
+      it('should restore the command string into the input element', () => {
+        mockSettings.preserveCommandPaletteLastInput = true;
+
+        // save input
+        const expectToRestore = `${commandTrigger} hello`;
+        sut.updateSuggestions(expectToRestore, mockChooser, null);
+
+        mockInputEl.value = '';
+        mockInputEl.selectionStart = 0;
+        mockInputEl.selectionEnd = 0;
+        sut.setSessionOpenMode(Mode.CommandList, null);
+
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+
+        expect(mockInputEl).toHaveProperty('value', expectToRestore);
+        // will auto select command text
+        // this make it easy to delete whole text
+        expect(mockInputEl.setSelectionRange).toHaveBeenCalledWith(
+          commandTrigger.length,
+          expectToRestore.length,
+        );
+        // if we open another mode, it wouldn't restore last input
+        mockInputEl.value = '';
+        sut.setSessionOpenMode(Mode.SymbolList, null);
+
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+        expect(mockInputEl).toHaveProperty('value', symbolTrigger);
+
+        mockSettings.preserveCommandPaletteLastInput = false;
+      });
+
+      it("shouldn't restore the command string into the input element without config", () => {
+        mockSettings.preserveCommandPaletteLastInput = false;
+
+        // save first input
+        const firstText = `${commandTrigger} hello`;
+        sut.updateSuggestions(firstText, mockChooser, null);
+
+        mockInputEl.value = '';
+        sut.setSessionOpenMode(Mode.CommandList, null);
+
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+
+        expect(mockInputEl).toHaveProperty('value', commandTrigger);
+      });
+
+      it('should restore the quicker switcher string into the input element', () => {
+        mockSettings.preserveCommandPaletteLastInput = false;
+        mockSettings.preserveQuickSwitcherLastInput = true;
+
+        sut.updateSuggestions(`${commandTrigger} any text`, mockChooser, null);
+
+        mockInputEl.value = '';
+        sut.setSessionOpenMode(Mode.CommandList, null);
+
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+
+        // will not save command last input if the configuration is falsy.
+        expect(mockInputEl).toHaveProperty('value', commandTrigger);
+
+        // save first input
+        const expectToRestore = `${editorTrigger} hello`;
+        sut.updateSuggestions(expectToRestore, mockChooser, null);
+
+        mockInputEl.value = '';
+        sut.setSessionOpenMode(Mode.EditorList, null);
+
+        sut.insertSessionOpenModeOrLastInputString(mockInputEl);
+        expect(mockInputEl).toHaveProperty('value', expectToRestore);
+
+        mockSettings.preserveQuickSwitcherLastInput = false;
       });
     });
   });

--- a/src/switcherPlus/__tests__/switcherPlus.test.ts
+++ b/src/switcherPlus/__tests__/switcherPlus.test.ts
@@ -152,7 +152,7 @@ describe('switcherPlus', () => {
     it('should forward to ModeHandler to get suggestions', () => {
       const insertCmdStringSpy = jest.spyOn(
         ModeHandler.prototype,
-        'insertSessionOpenModeCommandString',
+        'insertSessionOpenModeOrLastInputString',
       );
 
       const mhUpdateSuggestionsSpy = jest
@@ -186,7 +186,7 @@ describe('switcherPlus', () => {
     it('should forward to builtin system switcher if not handled by Modehandler', () => {
       const insertCmdStringSpy = jest.spyOn(
         ModeHandler.prototype,
-        'insertSessionOpenModeCommandString',
+        'insertSessionOpenModeOrLastInputString',
       );
 
       const mhUpdateSuggestionsSpy = jest

--- a/src/switcherPlus/modeHandler.ts
+++ b/src/switcherPlus/modeHandler.ts
@@ -95,7 +95,7 @@ export class ModeHandler {
       this.sessionOpenModeString = this.getHandler(mode).commandString;
     }
 
-    if (this.settings.preserveLastInput && lastInputInfoByMode[mode]) {
+    if (this.settings.preserveCommandPaletteLastInput && lastInputInfoByMode[mode]) {
       const lastInfo = lastInputInfoByMode[mode];
       this.lastInput = lastInfo.inputText;
     }

--- a/src/switcherPlus/modeHandler.ts
+++ b/src/switcherPlus/modeHandler.ts
@@ -106,7 +106,7 @@ export class ModeHandler {
     }
   }
 
-  insertSessionOpenModeCommandString(inputEl: HTMLInputElement): void {
+  insertSessionOpenModeOrLastInputString(inputEl: HTMLInputElement): void {
     const { sessionOpenModeString, lastInput } = this;
     if (lastInput && lastInput !== sessionOpenModeString) {
       inputEl.value = lastInput;

--- a/src/switcherPlus/modeHandler.ts
+++ b/src/switcherPlus/modeHandler.ts
@@ -95,9 +95,14 @@ export class ModeHandler {
       this.sessionOpenModeString = this.getHandler(mode).commandString;
     }
 
-    if (this.settings.preserveCommandPaletteLastInput && lastInputInfoByMode[mode]) {
-      const lastInfo = lastInputInfoByMode[mode];
-      this.lastInput = lastInfo.inputText;
+    if (lastInputInfoByMode[mode]) {
+      if (
+        (mode === Mode.CommandList && this.settings.preserveCommandPaletteLastInput) ||
+        (mode !== Mode.CommandList && this.settings.preserveQuickSwitcherLastInput)
+      ) {
+        const lastInfo = lastInputInfoByMode[mode];
+        this.lastInput = lastInfo.inputText;
+      }
     }
   }
 
@@ -105,8 +110,10 @@ export class ModeHandler {
     const { sessionOpenModeString, lastInput } = this;
     if (lastInput && lastInput !== sessionOpenModeString) {
       inputEl.value = lastInput;
-      // lastInput starts with `sessionOpenModeString`
-      inputEl.setSelectionRange(sessionOpenModeString.length, inputEl.value.length);
+      // `sessionOpenModeString` may `null` when in standard mode
+      // otherwise `lastInput` starts with `sessionOpenModeString`
+      const startsNumber = sessionOpenModeString ? sessionOpenModeString.length : 0;
+      inputEl.setSelectionRange(startsNumber, inputEl.value.length);
     } else if (sessionOpenModeString !== null && sessionOpenModeString !== '') {
       // update UI with current command string in the case were openInMode was called
       inputEl.value = sessionOpenModeString;

--- a/src/switcherPlus/modeHandler.ts
+++ b/src/switcherPlus/modeHandler.ts
@@ -144,6 +144,7 @@ export class ModeHandler {
     const inputInfo = this.determineRunMode(query, activeSugg, activeLeaf);
     this.inputInfo = inputInfo;
     const { mode } = inputInfo;
+
     exKeymap.updateKeymapForMode(mode);
     lastInputInfoByMode[mode] = inputInfo;
 

--- a/src/switcherPlus/modeHandler.ts
+++ b/src/switcherPlus/modeHandler.ts
@@ -103,24 +103,21 @@ export class ModeHandler {
 
   insertSessionOpenModeCommandString(inputEl: HTMLInputElement): void {
     const { sessionOpenModeString, lastInput } = this;
-
-    if (
-      sessionOpenModeString !== null &&
-      sessionOpenModeString !== '' &&
-      !inputEl.value
-    ) {
+    if (lastInput && lastInput !== sessionOpenModeString) {
+      inputEl.value = lastInput;
+      // lastInput starts with `sessionOpenModeString`
+      inputEl.setSelectionRange(sessionOpenModeString.length, inputEl.value.length);
+    } else if (sessionOpenModeString !== null && sessionOpenModeString !== '') {
       // update UI with current command string in the case were openInMode was called
       inputEl.value = sessionOpenModeString;
-
-      if (lastInput) {
-        inputEl.value += lastInput;
-        inputEl.setSelectionRange(sessionOpenModeString.length, inputEl.value.length);
-        this.lastInput = null;
-      }
 
       // reset to null so user input is not overridden the next time onInput is called
       this.sessionOpenModeString = null;
     }
+
+    // the same logic as `sessionOpenModeString`
+    // make sure it will not override user's normal input.
+    this.lastInput = null;
   }
 
   updateSuggestions(

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -48,7 +48,7 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
 
     protected updateSuggestions(): void {
       const { exMode, inputEl, chooser } = this;
-      exMode.insertSessionOpenModeCommandString(inputEl);
+      exMode.insertSessionOpenModeOrLastInputString(inputEl);
 
       if (!exMode.updateSuggestions(inputEl.value, chooser, this)) {
         super.updateSuggestions();

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -49,7 +49,6 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
     protected updateSuggestions(): void {
       const { exMode, inputEl, chooser } = this;
       exMode.insertSessionOpenModeCommandString(inputEl);
-
       if (!exMode.updateSuggestions(inputEl.value, chooser, this)) {
         super.updateSuggestions();
       }

--- a/src/switcherPlus/switcherPlus.ts
+++ b/src/switcherPlus/switcherPlus.ts
@@ -49,6 +49,7 @@ export function createSwitcherPlus(app: App, plugin: SwitcherPlusPlugin): Switch
     protected updateSuggestions(): void {
       const { exMode, inputEl, chooser } = this;
       exMode.insertSessionOpenModeCommandString(inputEl);
+
       if (!exMode.updateSuggestions(inputEl.value, chooser, this)) {
         super.updateSuggestions();
       }

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -266,6 +266,7 @@ export interface SettingsData {
   enableMatchPriorityAdjustments: boolean;
   matchPriorityAdjustments: Record<string, number>;
   preserveCommandPaletteLastInput: boolean;
+  preserveQuickSwitcherLastInput: boolean;
 }
 
 export interface SearchQuery {

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -265,7 +265,7 @@ export interface SettingsData {
   enabledRibbonCommands: Array<keyof typeof Mode>;
   enableMatchPriorityAdjustments: boolean;
   matchPriorityAdjustments: Record<string, number>;
-  preserveLastInput: boolean;
+  preserveCommandPaletteLastInput: boolean;
 }
 
 export interface SearchQuery {

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -265,6 +265,7 @@ export interface SettingsData {
   enabledRibbonCommands: Array<keyof typeof Mode>;
   enableMatchPriorityAdjustments: boolean;
   matchPriorityAdjustments: Record<string, number>;
+  preserveLastInput: boolean;
 }
 
 export interface SearchQuery {


### PR DESCRIPTION
Add the power to preserve user's last input value.
In some scene this make quick switcher more easier to use.


https://user-images.githubusercontent.com/13938334/216010658-c921b087-8408-4505-a501-c2d6b8ddd0d6.mp4


## Why Add Two Settings?

Because in Obisidian, Command Palette and Quick Switcher are different tools. The same as VSCode.
Using two settings make it configurable by difference people.

