### PR TITLE
[codex] Fix heading bookmark navigation in bookmarks mode

### DIFF
--- a/src/Handlers/__tests__/bookmarksHandler.test.ts
+++ b/src/Handlers/__tests__/bookmarksHandler.test.ts
@@ -20,6 +20,7 @@ import {
   makeHeading,
   makeInputInfo,
   makeBookmarkedFileSuggestion,
+  makeLoc,
 } from '@fixtures';
 import {
   App,
@@ -258,27 +259,110 @@ describe('bookmarksHandler', () => {
       item: makeBookmarksPluginFileItem({ subpath: '#Boule' }),
     });
     const mockEvt = mock<KeyboardEvent>();
+    const heading = makeHeading('Boule', 1, makeLoc(7, 2, 100), makeLoc(7, 9, 107));
 
     const navigateSpy = jest
       .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
       .mockReturnValueOnce();
-    const extractTabNavigationTypeSpy = jest
-      .spyOn(Handler.prototype, 'extractTabNavigationType')
-      .mockReturnValueOnce({ navType: false, splitDirection: 'vertical' });
-    mockWorkspace.openLinkText.mockResolvedValueOnce(undefined);
+    const getFileCacheSpy = jest
+      .spyOn(mockApp.metadataCache, 'getFileCache')
+      .mockReturnValueOnce({ headings: [heading] });
 
     sut.onChooseSuggestion(sugg, mockEvt);
 
-    expect(mockWorkspace.openLinkText).toHaveBeenCalledWith(
-      `${sugg.file.path}#Boule`,
-      sugg.file.path,
-      false,
-      { active: true },
+    expect(navigateSpy).toHaveBeenCalledWith(
+      mockEvt,
+      sugg.file,
+      expect.any(String),
+      expect.anything(),
     );
-    expect(navigateSpy).not.toHaveBeenCalled();
+    expect(navigateSpy.mock.calls[0][3]).toMatchObject({
+      active: true,
+      eState: {
+        active: true,
+        focus: true,
+        line: heading.position.start.line,
+        startLoc: heading.position.start,
+        endLoc: heading.position.end,
+        cursor: {
+          from: { line: heading.position.start.line, ch: heading.position.start.col },
+          to: { line: heading.position.start.line, ch: heading.position.start.col },
+        },
+      },
+    });
 
     navigateSpy.mockRestore();
-    extractTabNavigationTypeSpy.mockRestore();
+    getFileCacheSpy.mockRestore();
+  });
+
+  test('onChooseSuggestion() should open block bookmarks through navigateToLeafOrOpenFile', () => {
+    const sugg = makeBookmarkedFileSuggestion({
+      item: makeBookmarksPluginFileItem({ subpath: '#^bookmark-block' }),
+    });
+    const mockEvt = mock<KeyboardEvent>();
+    const position = {
+      start: makeLoc(11, 4, 250),
+      end: makeLoc(11, 18, 264),
+    };
+
+    const navigateSpy = jest
+      .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
+      .mockReturnValueOnce();
+    const getFileCacheSpy = jest.spyOn(mockApp.metadataCache, 'getFileCache').mockReturnValueOnce({
+      blocks: {
+        'bookmark-block': { id: 'bookmark-block', position },
+      },
+    });
+
+    sut.onChooseSuggestion(sugg, mockEvt);
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      mockEvt,
+      sugg.file,
+      expect.any(String),
+      expect.anything(),
+    );
+    expect(navigateSpy.mock.calls[0][3]).toMatchObject({
+      active: true,
+      eState: {
+        active: true,
+        focus: true,
+        line: position.start.line,
+        startLoc: position.start,
+        endLoc: position.end,
+        cursor: {
+          from: { line: position.start.line, ch: position.start.col },
+          to: { line: position.start.line, ch: position.start.col },
+        },
+      },
+    });
+
+    navigateSpy.mockRestore();
+    getFileCacheSpy.mockRestore();
+  });
+
+  test('onChooseSuggestion() should fall back to opening the file when bookmark subpath cannot be resolved', () => {
+    const sugg = makeBookmarkedFileSuggestion({
+      item: makeBookmarksPluginFileItem({ subpath: '#Missing heading' }),
+    });
+    const mockEvt = mock<KeyboardEvent>();
+
+    const navigateSpy = jest
+      .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
+      .mockReturnValueOnce();
+    const getFileCacheSpy = jest
+      .spyOn(mockApp.metadataCache, 'getFileCache')
+      .mockReturnValueOnce({
+        headings: [makeHeading('Other heading', 1)],
+      });
+
+    sut.onChooseSuggestion(sugg, mockEvt);
+
+    expect(navigateSpy).toHaveBeenCalledWith(mockEvt, sugg.file, expect.any(String));
+    expect(navigateSpy.mock.calls[0]).toHaveLength(3);
+
+    navigateSpy.mockRestore();
+    getFileCacheSpy.mockRestore();
   });
 
   describe('getCommandString', () => {

--- a/src/Handlers/__tests__/bookmarksHandler.test.ts
+++ b/src/Handlers/__tests__/bookmarksHandler.test.ts
@@ -33,6 +33,7 @@ import {
   BookmarksPluginInstance,
   BookmarksPluginItem,
   BookmarksPluginFileItem,
+  resolveSubpath,
 } from 'obsidian';
 import { filenameFromPath, stripMDExtensionFromPath } from 'src/utils';
 
@@ -249,7 +250,12 @@ describe('bookmarksHandler', () => {
 
     sut.onChooseSuggestion(sugg, mockEvt);
 
-    expect(navigateSpy).toHaveBeenCalledWith(mockEvt, sugg.file, expect.any(String));
+    expect(navigateSpy).toHaveBeenCalledWith(
+      mockEvt,
+      sugg.file,
+      expect.any(String),
+      expect.anything(),
+    );
 
     navigateSpy.mockRestore();
   });
@@ -267,6 +273,13 @@ describe('bookmarksHandler', () => {
     const getFileCacheSpy = jest
       .spyOn(mockApp.metadataCache, 'getFileCache')
       .mockReturnValueOnce({ headings: [heading] });
+    const resolveSubpathMock = jest.mocked(resolveSubpath).mockReturnValueOnce({
+      type: 'heading',
+      current: heading,
+      next: null,
+      start: heading.position.start,
+      end: heading.position.end,
+    });
 
     sut.onChooseSuggestion(sugg, mockEvt);
 
@@ -293,6 +306,7 @@ describe('bookmarksHandler', () => {
 
     navigateSpy.mockRestore();
     getFileCacheSpy.mockRestore();
+    resolveSubpathMock.mockReset();
   });
 
   test('onChooseSuggestion() should open block bookmarks through navigateToLeafOrOpenFile', () => {
@@ -304,14 +318,23 @@ describe('bookmarksHandler', () => {
       start: makeLoc(11, 4, 250),
       end: makeLoc(11, 18, 264),
     };
+    const block = { id: 'bookmark-block', position };
 
     const navigateSpy = jest
       .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
       .mockReturnValueOnce();
-    const getFileCacheSpy = jest.spyOn(mockApp.metadataCache, 'getFileCache').mockReturnValueOnce({
-      blocks: {
-        'bookmark-block': { id: 'bookmark-block', position },
-      },
+    const getFileCacheSpy = jest
+      .spyOn(mockApp.metadataCache, 'getFileCache')
+      .mockReturnValueOnce({
+        blocks: {
+          'bookmark-block': block,
+        },
+      });
+    const resolveSubpathMock = jest.mocked(resolveSubpath).mockReturnValueOnce({
+      type: 'block',
+      block,
+      start: position.start,
+      end: position.end,
     });
 
     sut.onChooseSuggestion(sugg, mockEvt);
@@ -339,9 +362,10 @@ describe('bookmarksHandler', () => {
 
     navigateSpy.mockRestore();
     getFileCacheSpy.mockRestore();
+    resolveSubpathMock.mockReset();
   });
 
-  test('onChooseSuggestion() should fall back to opening the file when bookmark subpath cannot be resolved', () => {
+  test('onChooseSuggestion() should fall back to opening the file at the default position when bookmark subpath cannot be resolved', () => {
     const sugg = makeBookmarkedFileSuggestion({
       item: makeBookmarksPluginFileItem({ subpath: '#Missing heading' }),
     });
@@ -358,8 +382,48 @@ describe('bookmarksHandler', () => {
 
     sut.onChooseSuggestion(sugg, mockEvt);
 
-    expect(navigateSpy).toHaveBeenCalledWith(mockEvt, sugg.file, expect.any(String));
-    expect(navigateSpy.mock.calls[0]).toHaveLength(3);
+    expect(navigateSpy).toHaveBeenCalledWith(
+      mockEvt,
+      sugg.file,
+      expect.any(String),
+      expect.anything(),
+    );
+    expect(navigateSpy.mock.calls[0][3]).toMatchObject({
+      active: true,
+      eState: {
+        active: true,
+        focus: true,
+        line: 0,
+      },
+    });
+
+    navigateSpy.mockRestore();
+    getFileCacheSpy.mockRestore();
+  });
+
+  test('onChooseSuggestion() should fall back to opening the file at the default position when the file has no metadata cache', () => {
+    const sugg = makeBookmarkedFileSuggestion({
+      item: makeBookmarksPluginFileItem({ subpath: '#Heading' }),
+    });
+    const mockEvt = mock<KeyboardEvent>();
+
+    const navigateSpy = jest
+      .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
+      .mockReturnValueOnce();
+    const getFileCacheSpy = jest
+      .spyOn(mockApp.metadataCache, 'getFileCache')
+      .mockReturnValueOnce(null);
+
+    sut.onChooseSuggestion(sugg, mockEvt);
+
+    expect(navigateSpy.mock.calls[0][3]).toMatchObject({
+      active: true,
+      eState: {
+        active: true,
+        focus: true,
+        line: 0,
+      },
+    });
 
     navigateSpy.mockRestore();
     getFileCacheSpy.mockRestore();

--- a/src/Handlers/__tests__/bookmarksHandler.test.ts
+++ b/src/Handlers/__tests__/bookmarksHandler.test.ts
@@ -253,6 +253,34 @@ describe('bookmarksHandler', () => {
     navigateSpy.mockRestore();
   });
 
+  test('onChooseSuggestion() should open the deep link for heading bookmarks', () => {
+    const sugg = makeBookmarkedFileSuggestion({
+      item: makeBookmarksPluginFileItem({ subpath: '#Boule' }),
+    });
+    const mockEvt = mock<KeyboardEvent>();
+
+    const navigateSpy = jest
+      .spyOn(BookmarksHandler.prototype, 'navigateToLeafOrOpenFile')
+      .mockReturnValueOnce();
+    const extractTabNavigationTypeSpy = jest
+      .spyOn(Handler.prototype, 'extractTabNavigationType')
+      .mockReturnValueOnce({ navType: false, splitDirection: 'vertical' });
+    mockWorkspace.openLinkText.mockResolvedValueOnce(undefined);
+
+    sut.onChooseSuggestion(sugg, mockEvt);
+
+    expect(mockWorkspace.openLinkText).toHaveBeenCalledWith(
+      `${sugg.file.path}#Boule`,
+      sugg.file.path,
+      false,
+      { active: true },
+    );
+    expect(navigateSpy).not.toHaveBeenCalled();
+
+    navigateSpy.mockRestore();
+    extractTabNavigationTypeSpy.mockRestore();
+  });
+
   describe('getCommandString', () => {
     it('should return bookmarksListCommand trigger for Bookmarks', () => {
       expect(sut.getCommandString()).toBe(bookmarksTrigger);

--- a/src/Handlers/bookmarksHandler.ts
+++ b/src/Handlers/bookmarksHandler.ts
@@ -21,9 +21,8 @@ import {
   BookmarksPluginFileItem,
   BookmarksPluginGroupItem,
   MetadataCache,
-  OpenViewState,
   Pos,
-  stripHeadingForLink,
+  resolveSubpath,
 } from 'obsidian';
 import { Handler } from './handler';
 import { BOOKMARKS_FACET_ID_MAP, SwitcherPlusSettings } from 'src/settings';
@@ -124,15 +123,11 @@ export class BookmarksHandler extends Handler<BookmarksSuggestion> {
   ): boolean {
     let handled = false;
     if (BookmarksHandler.isBookmarksPluginFileItem(sugg?.item)) {
-      const { file, item } = sugg;
+      const { file } = sugg;
       const errorContext = `Unable to open file from BookmarkSuggestion ${file?.path}`;
-      const openState = this.getBookmarkOpenViewState(file, item.subpath);
+      const openState = this.getOpenViewState(sugg);
 
-      if (openState) {
-        this.navigateToLeafOrOpenFile(evt, file, errorContext, openState);
-      } else {
-        this.navigateToLeafOrOpenFile(evt, file, errorContext);
-      }
+      this.navigateToLeafOrOpenFile(evt, file, errorContext, openState);
 
       handled = true;
     }
@@ -140,38 +135,31 @@ export class BookmarksHandler extends Handler<BookmarksSuggestion> {
     return handled;
   }
 
-  getBookmarkOpenViewState(file: TFile, subpath?: string): OpenViewState | null {
-    const position = this.getBookmarkSubpathPosition(file, subpath);
-
-    if (!position) {
-      return null;
+  override getPreferredViewLinePosition(sugg?: BookmarksSuggestion): Pos {
+    if (sugg && BookmarksHandler.isBookmarksPluginFileItem(sugg.item)) {
+      const position = this.getBookmarkSubpathPosition(sugg.file, sugg.item.subpath);
+      if (position) {
+        return position;
+      }
     }
 
-    const activeState = this.getOpenViewActiveState();
-    const { eState } = this.getOpenViewLinePositionState(position);
-    Object.assign(activeState.eState, eState);
-
-    return activeState;
+    return super.getPreferredViewLinePosition(sugg);
   }
 
   getBookmarkSubpathPosition(file: TFile, subpath?: string): Pos | null {
-    const fileCache = this.app.metadataCache.getFileCache(file);
-
-    if (!fileCache || !subpath) {
+    if (!subpath) {
       return null;
     }
 
-    if (subpath.startsWith('#^')) {
-      return fileCache.blocks?.[subpath.slice(2)]?.position ?? null;
+    const fileCache = this.app.metadataCache.getFileCache(file);
+    const resolved = fileCache ? resolveSubpath(fileCache, subpath) : null;
+
+    if (resolved?.type === 'block') {
+      return resolved.block.position;
     }
 
-    if (subpath.startsWith('#')) {
-      const headingSlug = subpath.slice(1);
-      const heading = fileCache.headings?.find((entry) => {
-        return stripHeadingForLink(entry.heading) === headingSlug;
-      });
-
-      return heading?.position ?? null;
+    if (resolved?.type === 'heading') {
+      return resolved.current.position;
     }
 
     return null;

--- a/src/Handlers/bookmarksHandler.ts
+++ b/src/Handlers/bookmarksHandler.ts
@@ -21,6 +21,9 @@ import {
   BookmarksPluginFileItem,
   BookmarksPluginGroupItem,
   MetadataCache,
+  OpenViewState,
+  Pos,
+  stripHeadingForLink,
 } from 'obsidian';
 import { Handler } from './handler';
 import { BOOKMARKS_FACET_ID_MAP, SwitcherPlusSettings } from 'src/settings';
@@ -122,31 +125,56 @@ export class BookmarksHandler extends Handler<BookmarksSuggestion> {
     let handled = false;
     if (BookmarksHandler.isBookmarksPluginFileItem(sugg?.item)) {
       const { file, item } = sugg;
+      const errorContext = `Unable to open file from BookmarkSuggestion ${file?.path}`;
+      const openState = this.getBookmarkOpenViewState(file, item.subpath);
 
-      if (item.subpath) {
-        const { navType } = this.extractTabNavigationType(evt);
-        const linkText = `${file.path}${item.subpath}`;
-
-        this.app.workspace
-          .openLinkText(linkText, file.path, navType, { active: true })
-          .catch((err) => {
-            console.log(
-              `Switcher++: Unable to open bookmark deep link ${item.subpath} in file ${file?.path}`,
-              err,
-            );
-          });
+      if (openState) {
+        this.navigateToLeafOrOpenFile(evt, file, errorContext, openState);
       } else {
-        this.navigateToLeafOrOpenFile(
-          evt,
-          file,
-          `Unable to open file from BookmarkSuggestion ${file?.path}`,
-        );
+        this.navigateToLeafOrOpenFile(evt, file, errorContext);
       }
 
       handled = true;
     }
 
     return handled;
+  }
+
+  getBookmarkOpenViewState(file: TFile, subpath?: string): OpenViewState | null {
+    const position = this.getBookmarkSubpathPosition(file, subpath);
+
+    if (!position) {
+      return null;
+    }
+
+    const activeState = this.getOpenViewActiveState();
+    const { eState } = this.getOpenViewLinePositionState(position);
+    Object.assign(activeState.eState, eState);
+
+    return activeState;
+  }
+
+  getBookmarkSubpathPosition(file: TFile, subpath?: string): Pos | null {
+    const fileCache = this.app.metadataCache.getFileCache(file);
+
+    if (!fileCache || !subpath) {
+      return null;
+    }
+
+    if (subpath.startsWith('#^')) {
+      return fileCache.blocks?.[subpath.slice(2)]?.position ?? null;
+    }
+
+    if (subpath.startsWith('#')) {
+      const headingSlug = subpath.slice(1);
+      const heading = fileCache.headings?.find((entry) => {
+        return stripHeadingForLink(entry.heading) === headingSlug;
+      });
+
+      return heading?.position ?? null;
+    }
+
+    return null;
   }
 
   getPreferredTitle(

--- a/src/Handlers/bookmarksHandler.ts
+++ b/src/Handlers/bookmarksHandler.ts
@@ -121,13 +121,27 @@ export class BookmarksHandler extends Handler<BookmarksSuggestion> {
   ): boolean {
     let handled = false;
     if (BookmarksHandler.isBookmarksPluginFileItem(sugg?.item)) {
-      const { file } = sugg;
+      const { file, item } = sugg;
 
-      this.navigateToLeafOrOpenFile(
-        evt,
-        file,
-        `Unable to open file from BookmarkSuggestion ${file?.path}`,
-      );
+      if (item.subpath) {
+        const { navType } = this.extractTabNavigationType(evt);
+        const linkText = `${file.path}${item.subpath}`;
+
+        this.app.workspace
+          .openLinkText(linkText, file.path, navType, { active: true })
+          .catch((err) => {
+            console.log(
+              `Switcher++: Unable to open bookmark deep link ${item.subpath} in file ${file?.path}`,
+              err,
+            );
+          });
+      } else {
+        this.navigateToLeafOrOpenFile(
+          evt,
+          file,
+          `Unable to open file from BookmarkSuggestion ${file?.path}`,
+        );
+      }
 
       handled = true;
     }

--- a/src/__mocks__/obsidian/index.ts
+++ b/src/__mocks__/obsidian/index.ts
@@ -19,6 +19,7 @@ import {
   MarkdownRenderer,
   prepareFuzzySearch,
   prepareSimpleSearch,
+  resolveSubpath,
   stripHeadingForLink,
 } from 'obsidian';
 import {
@@ -113,6 +114,8 @@ const mockStripHeadingForLink = mockFn<typeof stripHeadingForLink>().mockImpleme
   (heading) => heading,
 );
 
+const mockResolveSubpath = mockFn<typeof resolveSubpath>().mockReturnValue(null);
+
 // Mock parseYaml - returns undefined by default
 // Tests should override with mockReturnValue or mockImplementation as needed
 const mockParseYaml = mockFn<typeof parseYaml>();
@@ -133,6 +136,7 @@ export {
   mockParseLinktext as parseLinktext,
   mockParseYaml as parseYaml,
   mockStripHeadingForLink as stripHeadingForLink,
+  mockResolveSubpath as resolveSubpath,
   mockKeymap as Keymap,
   mockMarkdownRenderer as MarkdownRenderer,
   mockComponent as Component,


### PR DESCRIPTION
## Summary
Fix bookmark-mode selection for heading bookmarks so pressing Enter opens the saved subpath instead of only opening the backing file.

## Root cause
`BookmarksHandler.onChooseSuggestion()` treated every file bookmark like a plain file open and ignored `item.subpath`, even though Obsidian bookmark entries can target a heading or block within the file.

## Changes
- use `workspace.openLinkText()` for file bookmarks that include a `subpath`
- keep the existing file-open path for plain file bookmarks
- add a regression test covering heading bookmarks in bookmarks mode

## Validation
- `npx jest --runInBand --coverage=false src/Handlers/__tests__/bookmarksHandler.test.ts`
- `npm run build:fast`