### PR TITLE
ci: add build provenance attestations and bump Node to 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ env:
 jobs:
   build-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # required by Create release step
+      id-token: write       # required to mint OIDC token for Sigstore signing
+      attestations: write   # required to write attestation to the repo
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -31,6 +35,16 @@ jobs:
           pushd ./dist > /dev/null
           zip -r dist.zip ${{ env.PLUGIN_NAME }}
           popd > /dev/null
+
+      - name: Attest build artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/dist.zip
+            dist/${{ env.PLUGIN_NAME }}/main.js
+            dist/${{ env.PLUGIN_NAME }}/manifest.json
+            dist/${{ env.PLUGIN_NAME }}/styles.css
+            dist/${{ env.PLUGIN_NAME }}/versions.json
 
       - name: Create release
         # https://github.com/ncipollo/release-action


### PR DESCRIPTION
- Add `actions/attest-build-provenance@v2` to the release workflow so each release's artifacts get a Sigstore-signed provenance attestation.
- Bump release workflow Node from 18 (EOL) to 22, matching `engines.node` in package.json.