### PR TITLE
ci: bump GitHub Actions to node24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       attestations: write   # required to write attestation to the repo
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.21.1
           cache: 'npm'
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure') }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           use_oidc: true
           files: ./coverage/lcov.info


### PR DESCRIPTION
GitHub deprecated node20 in Actions runners. Force-promotion to node24 defaults on 2026-06-16; node20 is removed from the runner entirely on 2026-09-16. Bump action major versions whose action.yml (or internal JS actions) still declare using: node20.

- actions/checkout @v4 -> @v6 (v6 declares using: node24)
- actions/setup-node @v4 -> @v6 (v6 declares using: node24)
- codecov/codecov-action @v5 -> @v6 (composite; v6 bumps internal actions/github-script v7 -> v8 to get node24, and v6.0.1 includes the VULN-1652 template-injection security fix)