### PR TITLE
ci: switch to actions/attest@v4 for build provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           popd > /dev/null
 
       - name: Attest build artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: |
             dist/dist.zip


### PR DESCRIPTION
Replaces actions/attest-build-provenance@v2 in the release workflow.

actions/attest-build-provenance @v3 was the original node24 bump (resolving the node20 actions-runtime deprecation). @v4 turned the action into a thin wrapper over actions/attest@v4.1.0; per the v4 release notes, new implementations should use actions/attest directly.